### PR TITLE
Fix upload when the bin is not set

### DIFF
--- a/app/api/api.go
+++ b/app/api/api.go
@@ -128,6 +128,10 @@ func Upload(w http.ResponseWriter, r *http.Request, cfg config.Configuration, ct
 	r.Close = true
 
 	bin := r.Header.Get("bin")
+	if bin == "" {
+		// XXX: Should ensure that the bin does not exist from before.
+		bin = randomString(cfg.DefaultBinLength)
+	}
 	if err := verifyBin(bin); err != nil {
 		http.Error(w, "Invalid bin", 400)
 		return


### PR DESCRIPTION
when using curl --data-binary "@/path/to/some file" https://filebin.example.com/
the bin is not set, so generate a random bin