### PR TITLE
--logdir is not a valid flag

### DIFF
--- a/etc/systemd/filebin.service.example
+++ b/etc/systemd/filebin.service.example
@@ -5,7 +5,7 @@ Description=Filebin
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/filebin --filedir /srv/filebin/files --tempdir /srv/filebin/temp --logdir /var/log/filebin --baseurl https://filebin.example.com --port 8080 --cache-invalidation --access-log /var/log/filebin/access.log
+ExecStart=/usr/bin/filebin --filedir /srv/filebin/files --tempdir /srv/filebin/temp --baseurl https://filebin.example.com --port 8080 --cache-invalidation --access-log /var/log/filebin/access.log
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=filebin


### PR DESCRIPTION
Using the example-file yields this error:
```
flag provided but not defined: -logdir
```