### PR TITLE
50039d1 sort of makes Go 1.13 the minimum version to build this

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Filebin is a web application that facilitates convenient file sharing over the w
 
 ## Requirements
 
-To build Filebin, a Golang build environment (Go version 1.4 or higher) and some Golang packages are needed. The build procedure will produce a statically linked binary that doesn't require any external dependencies to run. It even comes with its own web server bundled.
+To build Filebin, a Golang build environment (Go version 1.13 or higher) and some Golang packages are needed. The build procedure will produce a statically linked binary that doesn't require any external dependencies to run. It even comes with its own web server bundled.
 
 The build process requires quite a bit of memory to complete successfully. Rough experiments show that up to 4 GB of memory is needed. At runtime, though, the memory requirements are modest. It seems that with the more memory requirements have droppet with recent releases of Go.
 
@@ -46,7 +46,7 @@ Install Golang:
 $ sudo yum/apt-get/brew install golang
 ```
 
-Last verified with Go 1.7.
+Last verified with Go 1.13.
 
 Create the Go workspace and set the ``GOPATH`` environment variable:
 


### PR DESCRIPTION
50039d1 made filebin quite a bit harder to build. Go 1.12 is the newest version included in Ubuntu at this time. Luckily, this changes with 20.04, which will include Go 1.13.

Either way, 50039d1 means you need Go 1.13 :)